### PR TITLE
Fixes for flex-grow

### DIFF
--- a/src/container/Calendar.react.js
+++ b/src/container/Calendar.react.js
@@ -48,6 +48,7 @@ type Props = {
   dayHeaderText?: Text.propTypes.style,
   dayRowView?: View.propTypes.style,
   dayView?: View.propTypes.style,
+  daySelectedView?: View.propTypes.style,
   dayText?: Text.propTypes.style,
   dayTodayText?: Text.propTypes.style,
   daySelectedText?: Text.propTypes.style,
@@ -151,6 +152,7 @@ export default class Calendar extends Component {
               dayHeaderText={this.props.dayHeaderText}
               dayRowView={this.props.dayRowView}
               dayView={this.props.dayView}
+              daySelectedView={this.props.daySelectedView}
               dayText={this.props.dayText}
               dayTodayText={this.props.dayTodayText}
               daySelectedText={this.props.daySelectedText}
@@ -193,7 +195,7 @@ Calendar.defaultProps = {
 
 const styles = StyleSheet.create({
   barView: {
-    flex: 1,
+    flexGrow: 1,
     padding: 5,
     alignItems: 'center',
   },

--- a/src/pure/DaySelector.react.js
+++ b/src/pure/DaySelector.react.js
@@ -33,6 +33,7 @@ type Props = {
   dayHeaderText?: Text.propTypes.style,
   dayRowView?: View.propTypes.style,
   dayView?: View.propTypes.style,
+  daySelectedView?: View.propTypes.style,
   dayText?: Text.propTypes.style,
   dayTodayText?: Text.propTypes.style,
   daySelectedText?: Text.propTypes.style,
@@ -194,7 +195,11 @@ export default class DaySelector extends Component {
               {_.map(week, (day, j) =>
                 <TouchableHighlight
                   key={j}
-                  style={[styles.dayView, this.props.dayView]}
+                  style={[
+                    styles.dayView,
+                    this.props.dayView,
+                    day.selected ? this.props.daySelectedView : null
+                  ]}
                   activeOpacity={day.valid ? 0.8 : 1}
                   underlayColor='transparent'
                   onPress={() => day.valid && this._onChange(day)}>
@@ -228,28 +233,28 @@ const styles = StyleSheet.create({
   headerView: {
     alignItems: 'center',
     borderBottomWidth: 1,
-    flex: 1,
+    flexGrow: 1,
     flexDirection: 'row',
     height: 35,
   },
   headerText: {
-    flex: 1,
+    flexGrow: 1,
     minWidth: 40,
     textAlign: 'center',
   },
   rowView: {
     alignItems: 'center',
     borderBottomWidth: 1,
-    flex: 1,
+    flexGrow: 1,
     flexDirection: 'row',
     height: 35,
   },
   dayView: {
-    flex: 1,
+    flexGrow: 1,
     margin: 5,
   },
   dayText: {
-    flex: 1,
+    flexGrow: 1,
     padding: 5,
     textAlign: 'center',
   },

--- a/src/pure/MonthSelector.react.js
+++ b/src/pure/MonthSelector.react.js
@@ -78,7 +78,7 @@ export default class MonthSelector extends Component {
             {_.map(group, (month, j) =>
               <TouchableHighlight
                 key={j}
-                style={{flex: 1}}
+                style={{flexGrow: 1}}
                 activeOpacity={month.valid ? 0.8 : 1}
                 underlayColor='transparent'
                 onPress={() => month.valid && this._onFocus(month.index)}>
@@ -106,7 +106,7 @@ MonthSelector.defaultProps = {
 
 const styles = StyleSheet.create({
   group: {
-    flex: 1,
+    flexGrow: 1,
     flexDirection: 'row',
   },
   disabledText: {
@@ -116,7 +116,7 @@ const styles = StyleSheet.create({
   monthText: {
     borderRadius: 5,
     borderWidth: 1,
-    flex: 1,
+    flexGrow: 1,
     margin: 5,
     padding: 10,
     textAlign: 'center',

--- a/src/pure/YearSelector.react.js
+++ b/src/pure/YearSelector.react.js
@@ -54,7 +54,7 @@ export default class YearSelector extends Component {
   render() {
     return (
       <View style={[{
-        flex: 1,
+        flexGrow: 1,
         // Wrapper view default style.
       },this.props.style]}>
         <Slider


### PR DESCRIPTION
* Changed `flex: ` to `flexGrow: ` according to
  https://github.com/facebook/react-native/commit/0a9b6bedb312eba22c5bc11498b1cc41363e5f27
* Added `daySelectedView` property, which allows to change selected day
  style, i.e. view backgroundColor, etc.