### PR TITLE
Added range of dates selected feature in only days

### DIFF
--- a/src/container/Calendar.react.js
+++ b/src/container/Calendar.react.js
@@ -35,6 +35,7 @@ const RIGHT_CHEVRON = '\u276F';
 type Props = {
   // The core properties.
   selected?: Moment,
+  selectedEnd?: Moment,
   onChange?: (date: Moment) => void,
   slideThreshold?: number,
   // Minimum and maximum date.
@@ -197,6 +198,7 @@ export default class Calendar extends Component {
             <DaySelector
               focus={this.state.focus}
               selected={this.props.selected}
+              selectedEnd={this.props.selectedEnd}
               onFocus={this._changeFocus}
               onChange={(date) => this.props.onChange && this.props.onChange(date)}
               monthOffset={this.state.monthOffset}

--- a/src/pure/DaySelector.react.js
+++ b/src/pure/DaySelector.react.js
@@ -162,7 +162,6 @@ export default class DaySelector extends Component {
     else if ( selected.isAfter(selectedEnd) || selected.isAfter(iterator) || iterator.isAfter(selectedEnd) ) {
       return false;
     }
-    console.log(selected, selectedEnd, iterator);
     return true;
   }
 

--- a/src/pure/DaySelector.react.js
+++ b/src/pure/DaySelector.react.js
@@ -22,6 +22,7 @@ type Props = {
   // Focus and selection control.
   focus: Moment,
   selected?: Moment,
+  selectedEnd?: Moment,
   onChange?: (date: Moment) => void,
   onFocus?: (date: Moment) => void,
   slideThreshold?: number,
@@ -151,6 +152,20 @@ export default class DaySelector extends Component {
     }
   }
 
+  _selectChecker = ({ selected, selectedEnd, iterator }) => {
+    if( !selected ) {
+      return false;
+    }
+    else if ( !selectedEnd ) {
+      return selected && iterator.isSame(selected, 'day');
+    }
+    else if ( selected.isAfter(selectedEnd) || selected.isAfter(iterator) || iterator.isAfter(selectedEnd) ) {
+      return false;
+    }
+    console.log(selected, selectedEnd, iterator);
+    return true;
+  }
+
   _computeDays = (props: Object) : Array<Array<Object>> => {
     let result = [];
     const currentMonth = props.focus.month();
@@ -164,7 +179,7 @@ export default class DaySelector extends Component {
         valid: this.props.maxDate.diff(iterator, 'seconds') >= 0 &&
                this.props.minDate.diff(iterator, 'seconds') <= 0,
         date: iterator.date(),
-        selected: props.selected && iterator.isSame(props.selected, 'day'),
+        selected: this._selectChecker({ selected: props.selected, selectedEnd: props.selectedEnd, iterator }),
         today: iterator.isSame(Moment(), 'day'),
       };
       // Add it to the result here.


### PR DESCRIPTION
After searching for a while I found your calendar component is amazing to be included in my app, except that I need a range of days for my users to choose. So I add this little feature to this project for only 'Days'. The sample usage is like this:

```
      <Calendar
        selected={Moment().startOf('day')}
        selectedEnd={Moment().add(4, 'days').startOf('day')}
        minDate={Moment().startOf('day')}
        maxDate={Moment().add(1, 'years').startOf('day')}
      />
```

I hope this is helping.