### PR TITLE
Dropdown option for selecting the year 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Here is a quick example of how it works, with custom appearance:
 
 ## Installation
 
-`npm install --save react-native-calendar-datepicker`
+`npm install --save react-native-calendar-datepicker && react-native link react-native-vector-icons`
 
 __Minimum react-native: "^0.33.0"__
 
@@ -50,7 +50,8 @@ import Moment from 'moment';
 | *startStage* | "day"/"month"/"year" | **[Default: "day"]** Whether you would like to select the day, month or year first.
 | *finalStage* | "day"/"month"/"year" | **[Default: "day"]** The last level of selection you want.
 | *slideThreshold* | number | **[Default: min([width / 3, 250])]** The number of pixels after which the slide event will be triggered.
-| *showArrows* | boolean | **[Default: false]** Whether you would like to show arrow buttons for moving between months.
+| *showArrows* | boolean | **[Default: true]** Whether you would like to show arrow buttons for moving between months.
+| *yearSelectorType* | "slider" or "dropdown" | **[Default: "slider"]** Whether you would like to use a slider or dropdown for selectin the year in your calendar
 
 ### Locale specific calendar
 
@@ -109,9 +110,10 @@ Below is the list of properties that can be used for styling. For a concrete exa
 
 Main Developer: [Vlad-Doru Ion](http://github.com/vlad-doru)
 
-Pull requests by: 
+Pull requests by:
 * [Jason Gaare](http://github.com/jasongaare)
-* [Igor Kurr](http://github.com/igorrKurr) 
+* [Igor Kurr](http://github.com/igorrKurr)
+* [Hossein Ahmadian-Yazdi](http://github.com/hahmadia) 
 
 ## License
 

--- a/demo/index.ios.js
+++ b/demo/index.ios.js
@@ -49,6 +49,7 @@ class demo extends Component {
             //finalStage="month"
             minDate={Moment().startOf('day')}
             maxDate={Moment().add(10, 'years').startOf('day')}
+            yearSelectorType={'dropdown'}
             //General Styling}
             style={{
               borderWidth: 1,

--- a/demo/package.json
+++ b/demo/package.json
@@ -8,6 +8,6 @@
   "dependencies": {
     "react": "^15.4.2",
     "react-native": "^0.41.2",
-    "react-native-calendar-datepicker": "^1.2.2"
+    "react-native-calendar-datepicker": "git://github.com/EdevMosaic/react-native-calendar-datepicker.git#year-selector-dropdown"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "lodash": "^4.15.0",
     "moment": "^2.14.1",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.0",
+    "react-native-vector-icons": "^4.4.2"
   },
   "description": "Cross platform calendar datepicker library for React Native.",
   "main": "index.js",

--- a/src/container/Calendar.react.js
+++ b/src/container/Calendar.react.js
@@ -73,6 +73,7 @@ type Props = {
   yearMaxTintColor?: string,
   yearSlider?: Slider.propTypes.style,
   yearText?: Text.propTypes.style,
+  yearSelectorType?: string,
 };
 type State = {
   stage: Stage,
@@ -240,6 +241,7 @@ export default class Calendar extends Component {
               maximumTrackTintColor={this.props.yearMaxTintColor}
               yearSlider={this.props.yearSlider}
               yearText={this.props.yearText}
+              yearSelectorType={this.props.yearSelectorType}
               /> :
             null
           }
@@ -254,6 +256,7 @@ Calendar.defaultProps = {
   startStage: DAY_SELECTOR,
   finalStage: DAY_SELECTOR,
   showArrows: true,
+  yearSelectorType: 'slider',
 };
 
 const styles = StyleSheet.create({

--- a/src/pure/DaySelector.react.js
+++ b/src/pure/DaySelector.react.js
@@ -12,6 +12,7 @@ import {
   View,
   Text,
   StyleSheet,
+  Platform
 } from 'react-native';
 
 // Component specific libraries.
@@ -60,7 +61,7 @@ export default class DaySelector extends Component {
   _slide = (dx : number) => {
     this.refs.wrapper.setNativeProps({
       style: {
-        left: dx,
+        left: Platform.OS === 'ios' ? dx : 0,
       }
     })
   };

--- a/src/pure/MonthSelector.react.js
+++ b/src/pure/MonthSelector.react.js
@@ -33,7 +33,6 @@ type Props = {
 };
 type State = {
   months: Array<Array<Object>>,
-  selectedMonth?: number,
 };
 
 export default class MonthSelector extends Component {
@@ -67,14 +66,6 @@ export default class MonthSelector extends Component {
     };
   }
 
-  componentWillReceiveProps(nextProps: Object) {
-    if (this.props.selected != nextProps.selected) {
-      this.setState({
-        selectedMonth: nextProps.selected && nextProps.selected.month(),
-      })
-    }
-  }
-
   _onFocus = (index : number) : void => {
     let focus = Moment(this.props.focus);
     focus.month(index);
@@ -100,7 +91,7 @@ export default class MonthSelector extends Component {
                   this.props.monthText,
                   month.valid ? null : styles.disabledText,
                   month.valid ? null : this.props.monthDisabledText,
-                  month.index === this.state.selectedMonth ? this.props.selectedText : null,
+                  month.index ===  (this.props.selected && this.props.selected.month()) ? this.props.selectedText : null,
                 ]}>
                   {month.name}
                 </Text>

--- a/src/pure/YearSelector.react.js
+++ b/src/pure/YearSelector.react.js
@@ -11,14 +11,13 @@ import {
   Text,
   StyleSheet,
   Picker,
-  Button
 } from 'react-native';
 import ViewPropTypes from '../util/ViewPropTypes';
 
 // Component specific libraries.
 import _ from 'lodash';
 import Moment from 'moment';
-import Icon from 'react-native-vector-icons/FontAwesome';
+import Icon from 'react-native-vector-icons/dist/FontAwesome';
 
 type Props = {
   style?: ViewPropTypes.style,
@@ -33,6 +32,7 @@ type Props = {
   maximumTrackTintColor?: string,
   yearSlider?: Slider.propTypes.style,
   yearText?: Text.propTypes.style,
+  yearSelectorType?: string,
 };
 type State = {
   year: Number,
@@ -56,6 +56,42 @@ export default class YearSelector extends Component {
     this.props.onFocus && this.props.onFocus(date);
   }
 
+  renderSliderOrDropdown(values) {
+    if (this.props.yearSelectorType === 'dropdown') {
+      return(
+        <View>
+          <Picker
+            selectedValue={`${this.state.year}`}
+            onValueChange={(year) => this.setState({year})}
+          >
+            {values}
+          </Picker>
+          <Icon.Button name="check" size={40} alignSelf="center" underlayColor="transparent" backgroundColor="transparent" borderRadius={0} color={"black"} onPress={() => this._onFocus(this.state.year)}/>
+        </View>
+      );
+    }
+
+    return(
+      <View>
+        <Slider
+            minimumValue={this.props.minDate.year()}
+            maximumValue={this.props.maxDate.year()}
+            // TODO: Add a property for this.
+            minimumTrackTintColor={this.props.minimumTrackTintColor}
+            maximumTrackTintColor={this.props.maximumTrackTintColor}
+            step={1}
+            value={this.props.focus.year()}
+            onValueChange={(year) => this.setState({year})}
+            onSlidingComplete={(year) => this._onFocus(year)}
+            style={[this.props.yearSlider]}
+        />
+        <Text style={[styles.yearText, this.props.yearText]}>
+          {this.state.year}
+        </Text>
+      </View>
+    );
+  }
+
   render() {
     const values = Array(this.props.maxDate.year() - this.props.minDate.year() + 1).fill().map((_,i) => (
       <Picker.Item
@@ -69,13 +105,7 @@ export default class YearSelector extends Component {
         flexGrow: 1,
         // Wrapper view default style.
       },this.props.style]}>
-        <Picker
-          selectedValue={this.state.year}
-          onValueChange={(year) => this.setState({year})}
-        >
-        {values}
-        </Picker>
-        <Icon name="check" size={18} color={"rgba(255,255,255, 0.6)"} />
+        {this.renderSliderOrDropdown(values)}
       </View>
     );
   }

--- a/src/pure/YearSelector.react.js
+++ b/src/pure/YearSelector.react.js
@@ -10,12 +10,15 @@ import {
   View,
   Text,
   StyleSheet,
+  Picker,
+  Button
 } from 'react-native';
 import ViewPropTypes from '../util/ViewPropTypes';
 
 // Component specific libraries.
 import _ from 'lodash';
 import Moment from 'moment';
+import Icon from 'react-native-vector-icons/FontAwesome';
 
 type Props = {
   style?: ViewPropTypes.style,
@@ -54,26 +57,25 @@ export default class YearSelector extends Component {
   }
 
   render() {
+    const values = Array(this.props.maxDate.year() - this.props.minDate.year() + 1).fill().map((_,i) => (
+      <Picker.Item
+        key={`${this.props.minDate.year() + i}`}
+        value={`${this.props.minDate.year() + i}`}
+        label={`${this.props.minDate.year() + i}`}
+      />
+    ));
     return (
       <View style={[{
         flexGrow: 1,
         // Wrapper view default style.
       },this.props.style]}>
-        <Slider
-          minimumValue={this.props.minDate.year()}
-          maximumValue={this.props.maxDate.year()}
-          // TODO: Add a property for this.
-          minimumTrackTintColor={this.props.minimumTrackTintColor}
-          maximumTrackTintColor={this.props.maximumTrackTintColor}
-          step={1}
-          value={this.props.focus.year()}
+        <Picker
+          selectedValue={this.state.year}
           onValueChange={(year) => this.setState({year})}
-          onSlidingComplete={(year) => this._onFocus(year)}
-          style={[this.props.yearSlider]}
-          />
-        <Text style={[styles.yearText, this.props.yearText]}>
-          {this.state.year}
-        </Text>
+        >
+        {values}
+        </Picker>
+        <Icon name="check" size={18} color={"rgba(255,255,255, 0.6)"} />
       </View>
     );
   }


### PR DESCRIPTION
Hello!

When working with the calendar component, I realised that the year selection slider could at times be annoying. It was hard to select a year when the range of years was a lot and especially on small screen phones, it could be a pain to get the accurate date.

That is why I decided to add an optional prop for making the year selection either through a slider or a dropdown menu. Now you have the ability to select the year through the default slider or decide to use the dropdown instead.

![image](https://user-images.githubusercontent.com/17804942/32446905-6eecff8e-c2d8-11e7-9d09-b4b3ea8a2f3b.png)

Also, I experienced issues with sliding between months on android phone so I have temporarily disabled it in this pull request as well. (Related to issue https://github.com/vlad-doru/react-native-calendar-datepicker/issues/11). If someone fixes it, they can enable it again and make a pull request for that issue.

Hoping that my pull request can get approved and merged into master! Thank you!